### PR TITLE
Add TypeScript definitions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 coverage/
 mdast-util-definitions.js
 mdast-util-definitions.min.js
+*.md

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "index.js"
   ],
   "dependencies": {
+    "@types/mdast": "^3.0.3",
     "unist-util-visit": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^16.0.0",
+    "dtslint": "^3.4.2",
     "nyc": "^15.0.0",
     "prettier": "^2.0.5",
     "remark": "^12.0.0",
@@ -44,13 +46,14 @@
     "xo": "^0.29.1"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write . && xo --fix",
+    "format": "remark . -qfo && prettier --write . && xo --fix --ignore types",
     "build-bundle": "browserify . -s mdastUtilDefinitions > mdast-util-definitions.js",
     "build-mangle": "browserify . -s mdastUtilDefinitions -p tinyify > mdast-util-definitions.min.js",
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test.js",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-types": "dtslint types",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
   },
   "nyc": {
     "check-coverage": true,

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "devDependencies": {
     "browserify": "^16.0.0",
     "nyc": "^15.0.0",
-    "prettier": "^1.0.0",
-    "remark": "^11.0.0",
-    "remark-cli": "^7.0.0",
-    "remark-preset-wooorm": "^6.0.0",
+    "prettier": "^2.0.5",
+    "remark": "^12.0.0",
+    "remark-cli": "^8.0.0",
+    "remark-preset-wooorm": "^7.0.0",
     "tape": "^4.0.0",
     "tinyify": "^2.0.0",
-    "xo": "^0.26.0"
+    "xo": "^0.29.1"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
+    "format": "remark . -qfo && prettier --write . && xo --fix",
     "build-bundle": "browserify . -s mdastUtilDefinitions > mdast-util-definitions.js",
     "build-mangle": "browserify . -s mdastUtilDefinitions -p tinyify > mdast-util-definitions.min.js",
     "build": "npm run build-bundle && npm run build-mangle",

--- a/test.js
+++ b/test.js
@@ -4,12 +4,12 @@ var test = require('tape')
 var remark = require('remark')
 var definitions = require('.')
 
-test('mdast-util-definitions', function(t) {
+test('mdast-util-definitions', function (t) {
   var getDefinition
   var tree
 
   t.throws(
-    function() {
+    function () {
       definitions()
     },
     /mdast-util-definitions expected node/,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,29 @@
+// Minimum TypeScript Version: 3.2
+import {Node} from 'unist'
+import {Definition} from 'mdast'
+
+declare namespace definitions {
+  interface Options {
+    /**
+     * Turn on (`true`) to use CommonMark precedence: ignore definitions found later for duplicate definitions. The default behavior is to prefer the last found definition.
+     *
+     * @default false
+     */
+    commonmark: boolean
+  }
+
+  /**
+   * @param identifier [Identifier](https://github.com/syntax-tree/mdast#association) of [definition](https://github.com/syntax-tree/mdast#definition).
+   */
+  type DefinitionCache = (identifier: string) => Definition | null
+}
+
+/**
+ * Create a cache of all [definition](https://github.com/syntax-tree/mdast#definition)s in [`node`](https://github.com/syntax-tree/unist#node).
+ */
+declare function definitions(
+  node: Node,
+  options?: definitions.Options
+): definitions.DefinitionCache
+
+export = definitions

--- a/types/mdast-util-definitions-tests.ts
+++ b/types/mdast-util-definitions-tests.ts
@@ -1,0 +1,10 @@
+import remark = require('remark')
+import definitions = require('mdast-util-definitions')
+
+const ast = remark().parse('[example]: https://example.com "Example"')
+
+const definition = definitions(ast)
+
+definition('example')
+
+definition('foo')

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "mdast-util-definitions": ["index.d.ts"]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-redundant-jsdoc": false,
+    "semicolon": false,
+    "whitespace": false
+  }
+}


### PR DESCRIPTION
Dependencies have been bumped before adding types.

This adds a new dependency on `@types/mdast`.